### PR TITLE
Glide destination updates

### DIFF
--- a/airbyte-integrations/connectors/destination-glide/README.md
+++ b/airbyte-integrations/connectors/destination-glide/README.md
@@ -5,37 +5,48 @@ For information about how to use this connector within Airbyte, see [the documen
 
 ## Development
 
-The active todo list is at [./todo.md].
-The gist of the Glide-specific code is in `/destination_glide/destination.py` and `/destination_glide/glide.py`.
+The active todo list is at `./todo.md`.
 
-### Prerequisites
+The gist of the Glide-specific code is in `destination_glide/destination.py` and `destination_glide/glide.py`.
 
-- Python (`^3.9`, tested recently with `3.12.3`)
-- Poetry (`^1.7`, tested recently with `1.8.3_1`)
+### Setup
 
-I used homebrew for installing these prerequisites on macOS.
+1. Ensure you have the following prerequisites installed:
 
-### Unit Tests
+    - Python (`^3.9`, tested recently with `3.12.3`)
+    - Poetry (`^1.7`, tested recently with `1.8.3_1`)
 
-The unit tests for that code are in `/destination-glide/unit_tests`. To run them run:
+    You can use homebrew to install these on macOS.
+
+2. Once you have the above, run:
+
+```
+poetry install
+```
+
+### Running the Tests
+
+Create the file `secrets/config.json`. It must confirm to the configuration specification in `destination_glide/spec.json`, which also specifies the configuration UI within the Airbyte product itself for configuring the destination.
+
+It should be something like:
+
+```json
+{
+  "api_host": "https://api.staging.glideapps.com",
+  "api_path_root": "",
+  "api_key": "decafbad-1234-1234-1234-decafbad"
+}
+```
+
+#### Unit Tests
+
+The unit tests for that code are in `destination-glide/unit_tests`. To run them run:
 
 ```sh
 ./scripts/test-unit.sh
 ```
 
-### Integration Tests
-
-The destination has a configuration in `/secrets/config.json`. That file must confirm to the configuration specification in `/destination_glide/spec.json`. It should be something like:
-
-```json
-{
-  "api_host": "http://localhost:5005",
-  "api_path_root": "api",
-  "api_key": "decafbad-1234-1234-1234-decafbad"
-}
-```
-
-The spec also specifies the configuration UI within the Airbyte product itself for configuring the destination.
+#### Integration Tests
 
 There are a set of simple integration tests that Airbyte provides that can be triggered with the following scripts:
 

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
@@ -135,7 +135,8 @@ class DestinationGlide(Destination):
             glide.commit()
             logger.info(f"Committed stream '{stream_name}' to Glide.")
 
-        pass
+        # see https://stackoverflow.com/a/36863998
+        yield from ()
 
     def check(self, logger: logging.Logger, config: Mapping[str, Any]) -> AirbyteConnectionStatus:
         """

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
@@ -91,8 +91,7 @@ class DestinationGlide(Destination):
             if configured_stream.destination_sync_mode != DestinationSyncMode.overwrite:
                 raise Exception(f'Only destination sync mode overwrite is supported, but received "{configured_stream.destination_sync_mode}".')  # nopep8 because https://github.com/hhatto/autopep8/issues/712
 
-            glide = create_table_client_for_stream(
-                configured_stream.stream.name)
+            glide = create_table_client_for_stream(configured_stream.stream.name)
             # upsert the GBT with schema to set_schema for dumping the data into it
             columns = []
             properties = configured_stream.stream.json_schema["properties"]

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
@@ -79,10 +79,10 @@ class DestinationGlide(Destination):
         # configure the table based on the stream catalog:
         # choose a strategy based on config:
 
-        def create_table_client_for_stream(stream_name):
+        def create_table_client_for_stream(stream_name, columns):
             # TODO: sanitize stream_name chars and length for GBT name
             glide = GlideBigTableFactory.create()
-            glide.init(api_key, stream_name, api_host, api_path_root)
+            glide.init(api_key, stream_name, columns, api_host, api_path_root)
             return glide
 
         table_clients = {}
@@ -91,7 +91,6 @@ class DestinationGlide(Destination):
             if configured_stream.destination_sync_mode != DestinationSyncMode.overwrite:
                 raise Exception(f'Only destination sync mode overwrite is supported, but received "{configured_stream.destination_sync_mode}".')  # nopep8 because https://github.com/hhatto/autopep8/issues/712
 
-            glide = create_table_client_for_stream(configured_stream.stream.name)
             # upsert the GBT with schema to set_schema for dumping the data into it
             columns = []
             properties = configured_stream.stream.json_schema["properties"]
@@ -102,11 +101,10 @@ class DestinationGlide(Destination):
                     Column(prop_name, airbyteTypeToGlideType(prop_type))
                 )
 
-            glide.set_schema(columns)
+            glide = create_table_client_for_stream(configured_stream.stream.name, columns)
             table_clients[configured_stream.stream.name] = glide
 
         # stream the records into the GBT:
-        buffers = defaultdict(list)
         logger.debug("Processing messages...")
         for message in input_messages:
             logger.debug(f"processing message {message.type}...")
@@ -119,36 +117,16 @@ class DestinationGlide(Destination):
                     continue
 
                 # add to buffer
-                record_data = message.record.data
-                record_id = str(uuid.uuid4())
-                stream_buffer = buffers[stream_name]
-                stream_buffer.append(
-                    (record_id, datetime.datetime.now().isoformat(), record_data))
+                client = table_clients[stream_name]
+                client.add_row(message.record.data)
                 logger.debug("buffering record complete.")
 
             elif message.type == Type.STATE:
                 # `Type.State` is a signal from the source that we should save the previous batch of `Type.RECORD` messages to the destination.
                 #   It is a checkpoint that enables partial success.
                 #   See https://docs.airbyte.com/understanding-airbyte/airbyte-protocol#state--checkpointing
-                logger.info(f"Writing buffered records to Glide API from {len(buffers.keys())} streams...")  # nopep8
-                for stream_name in buffers.keys():
-                    stream_buffer = buffers[stream_name]
-                    logger.info(f"Saving buffered records to Glide API (stream: '{stream_name}', record count: '{len(stream_buffer)}')...")  # nopep8
-                    DATA_INDEX = 2
-                    data_rows = [row_tuple[DATA_INDEX]
-                                 for row_tuple in stream_buffer]
-                    if len(data_rows) > 0:
-                        if stream_name not in table_clients:
-                            raise Exception(
-                                f"Stream '{stream_name}' not found in table_clients")
-                        glide = table_clients[stream_name]
-                        glide.add_rows(data_rows)
-                    stream_buffer.clear()
-                    logger.info(f"Saving buffered records to Glide API complete.")  # nopep8 because https://github.com/hhatto/autopep8/issues/712
-
-                # dump all buffers now as we just wrote them to the table:
-                buffers = defaultdict(list)
-                yield message
+                # FIXME: I don't think partial success applies to us since we only support overwrite mode anyway?
+                logger.info(f"Ignoring state message: {message.state}")
             else:
                 logger.warn(f"Ignoring unknown Airbyte input message type: {message.type}")  # nopep8 because https://github.com/hhatto/autopep8/issues/712
 

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
@@ -46,6 +46,14 @@ class Column(dict):
 
 
 class GlideBigTableBase(ABC):
+    """
+    An API client for interacting with a Glide Big Table. The intention is to
+    create a new table or update an existing table including the table's schema
+    and the table's rows.
+
+    The protocol is to call `init`, `set_schema`, `add_rows` one or more times, and `commit` in that order.
+    """
+
     def headers(self) -> Dict[str, str]:
         return {
             "Content-Type": "application/json",
@@ -54,14 +62,6 @@ class GlideBigTableBase(ABC):
 
     def url(self, path: str) -> str:
         return f"{self.api_host}/{self.api_path_root + '/' if self.api_path_root != '' else ''}{path}"
-
-    """
-    An API client for interacting with a Glide Big Table. The intention is to
-    create a new table or update an existing table including the table's schema
-    and the table's rows.
-
-    The protocol is to call `init`, `set_schema`, `add_rows` one or more times, and `commit` in that order.
-    """
 
     def init(self, api_key, table_name, api_host="https://api.glideapps.com", api_path_root=""):
         """

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
@@ -161,7 +161,7 @@ class GlideBigTableRestStrategy(GlideBigTableBase):
     def create_table_from_stash(self) -> None:
         logger.info(f"Creating new table for table name '{self.table_name}'...") # nopep8
         r = requests.post(
-            self.url(f"tables"),
+            self.url(f"tables?onSchemaError=dropColumns"),
             headers=self.headers(),
             json={
                 "name": self.table_name,
@@ -183,7 +183,7 @@ class GlideBigTableRestStrategy(GlideBigTableBase):
     def overwrite_table_from_stash(self, table_id) -> None:
         # overwrite the specified table's schema and rows with the stash:
         r = requests.put(
-            self.url(f"tables/{table_id}"),
+            self.url(f"tables/{table_id}?onSchemaError=dropColumns"),
             headers=self.headers(),
             json={
                 "schema": {

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/glide.py
@@ -125,7 +125,7 @@ class GlideBigTableRestStrategy(GlideBigTableBase):
         rows = self.buffer
         if len(rows) == 0:
             return
-        self.buffer.clear()
+        self.buffer = []
 
         path = f"stashes/{self.stash_id}/{self.stash_serial}"
         logger.debug(f"Flushing {len(rows)} rows to {path} ...")

--- a/airbyte-integrations/connectors/destination-glide/destination_glide/spec.json
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/spec.json
@@ -1,7 +1,7 @@
 {
   "documentationUrl": "https://docs.airbyte.com/integrations/destinations/glide",
   "supported_destination_sync_modes": ["overwrite"],
-  "supportsIncremental": true,
+  "supportsIncremental": false,
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Destination Glide",

--- a/airbyte-integrations/connectors/destination-glide/integration_tests/GlideBigTableRestStrategy_int_test.py
+++ b/airbyte-integrations/connectors/destination-glide/integration_tests/GlideBigTableRestStrategy_int_test.py
@@ -18,7 +18,7 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
 
     api_key = None
     
-    env = "prod"
+    env = "staging"
     if (env == "poc"):
         api_host = "https://functions.prod.internal.glideapps.com"
         api_path_root = "api"
@@ -37,7 +37,7 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
         if self.api_key is None:
             raise Exception("GLIDE_API_KEY environment variable is not set.")
 
-    # The protocol is to call `init`, `set_schema`, `add_rows` one or more times, and `commit` in that order.
+    # The protocol is to call `init`, `add_row` or `add_rows` one or more times, and `commit` in that order.
     
     def test_new_table(self):
         
@@ -45,14 +45,11 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
         gbt = GlideBigTableFactory().create()
 
         table_name = f"test-table-{str(uuid.uuid4())}"
-        gbt.init(self.api_key, table_name, self.api_host, self.api_path_root)
-        
-        # set_schema
         test_columns = [
             Column("test-str", "string"),
             Column("test-num", "number")
         ]
-        gbt.set_schema(test_columns)
+        gbt.init(self.api_key, table_name, test_columns, self.api_host, self.api_path_root)
     
         # add_rows
         for batch in range(3):
@@ -82,15 +79,12 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
         # init
         
         table_name = f"test-table-{str(uuid.uuid4())}"
-        gbt = GlideBigTableFactory().create()
-        gbt.init(self.api_key, table_name, self.api_host, self.api_path_root)
-        
-        # set_schema
         test_columns = [
             Column("test-str", "string"),
             Column("test-num", "number")
         ]
-        gbt.set_schema(test_columns)
+        gbt = GlideBigTableFactory().create()
+        gbt.init(self.api_key, table_name, test_columns, self.api_host, self.api_path_root)
     
         # add_rows
         test_rows = [
@@ -108,8 +102,7 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
 
         # now do the update the second table now:
         gbt = GlideBigTableFactory().create()
-        gbt.init(self.api_key, table_name, self.api_host, self.api_path_root)
-        gbt.set_schema(test_columns)
+        gbt.init(self.api_key, table_name, test_columns, self.api_host, self.api_path_root)
 
         now = datetime.now()
         test_rows = [

--- a/airbyte-integrations/connectors/destination-glide/scripts/push-docker-image.sh
+++ b/airbyte-integrations/connectors/destination-glide/scripts/push-docker-image.sh
@@ -16,7 +16,7 @@ docker inspect --format='Pushing the local image "{{index .RepoTags 0}}" created
 tags=$(gcloud artifacts docker tags list $GLIDE_DOCKER_IMAGE_NAME --format="get(tag)")
 
 # Sort the tags and get the highest one
-highest_tag=$(echo "$tags" | awk -F'/' '{print $NF}' | sort -V | tail -n 1)
+highest_tag=$(echo "$tags" | awk -F'/' '{print $NF}' | sed 's/latest//g' | sort -V | tail -n 1)
 
 echo "found highest tag on remote: $highest_tag"
 

--- a/airbyte-integrations/connectors/destination-glide/unit_tests/GlideBigTableRestStrategy_test.py
+++ b/airbyte-integrations/connectors/destination-glide/unit_tests/GlideBigTableRestStrategy_test.py
@@ -12,7 +12,7 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
     api_path_root = "test/api/path/root"
     table_id = ""
     table_name = ""
-    stash_id = ""
+    batch_size = 100
 
     test_columns = [
         Column("test-str", "string"),
@@ -22,64 +22,26 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
     def setUp(self):
         self.table_id = f"test-table-id-{str(uuid.uuid4())}"
         self.table_name = f"test-table-name-{str(uuid.uuid4())}"
-        self.stash_id = f"stash-id-{str(uuid.uuid4())}"
         self.gbt = GlideBigTableRestStrategy()
-        self.gbt.init(self.api_key, self.table_name, self.api_host, self.api_path_root)
+        self.gbt.init(self.api_key, self.table_name, self.test_columns, self.api_host, self.api_path_root, self.batch_size)
 
-    def mock_post_for_set_schema(self, mock_post):
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {
-            "data": {
-                "stashID": self.stash_id
-            }
-        }
-
-    @patch.object(requests, "post")
-    def test_set_schema_valid(self, mock_post):
-        self.mock_post_for_set_schema(mock_post)
-
-        test_columns = [
-            Column("test-str", "string"),
-            Column("test-num", "number")
-        ]
-        self.gbt.set_schema(test_columns)
-
-        mock_post.assert_called_once()
-
-    @patch.object(requests, "post")
-    def test_set_schema_invalid_col_type(self, mock_post):
-        self.mock_post_for_set_schema(mock_post)
-
+    def test_invalid_col_type(self):
         with self.assertRaises(ValueError):
-            self.gbt.set_schema([
-                Column("test-str", "string"),
-                Column("test-num", "invalid-type")
-            ])
+            Column("test-num", "invalid-type")
 
     @patch.object(requests, "post")
     def test_add_rows(self, mock_post):
-        self.mock_post_for_set_schema(mock_post)
-
-        self.gbt.set_schema(self.test_columns)
-        mock_post.reset_mock()
         test_rows = [
             {"test-str": "one", "test-num": 1},
             {"test-str": "two", "test-num": 2}
         ]
         self.gbt.add_rows(test_rows)
-
-        mock_post.assert_called_once()
-        self.assertEqual(
-            mock_post.call_args.kwargs["json"], test_rows)
+        mock_post.assert_not_called()
 
     @patch.object(requests, "post")
     def test_add_rows_batching(self, mock_post):
-        self.mock_post_for_set_schema(mock_post)
-
-        self.gbt.set_schema(self.test_columns)
-
-        mock_post.reset_mock()
-        TEST_ROW_COUNT = 2001
+        # the batch size isn't currently strict, so the extra row will be sent in the same batch
+        TEST_ROW_COUNT = self.batch_size + 1
         test_rows = list([
             {"test-str": f"one {i}", "test-num": i}
             for i in range(TEST_ROW_COUNT)
@@ -87,22 +49,16 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
 
         self.gbt.add_rows(test_rows)
 
-        self.assertEqual(5, mock_post.call_count)
-        # validate that the last row is what we expect:
-        self.assertEqual(mock_post.call_args.kwargs["json"],
-                         [
-            {"test-str": f"one {TEST_ROW_COUNT-1}", "test-num": TEST_ROW_COUNT-1}
-        ])
+        self.assertEqual(1, mock_post.call_count)
+        self.assertEqual(mock_post.call_args.kwargs["json"], test_rows)
 
     def test_commit_with_pre_existing_table(self):
         with patch.object(requests, "post") as mock_post:
-            self.mock_post_for_set_schema(mock_post)
-            self.gbt.set_schema(self.test_columns)
-            test_rows = [
-                {"test-str": "one", "test-num": 1},
-                {"test-str": "two", "test-num": 2}
-            ]
-            mock_post.reset_mock()
+            TEST_ROW_COUNT = self.batch_size
+            test_rows = list([
+                {"test-str": f"one {i}", "test-num": i}
+                for i in range(TEST_ROW_COUNT)
+            ])
             self.gbt.add_rows(test_rows)
 
             with patch.object(requests, "get") as mock_get:
@@ -121,21 +77,16 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
                     self.gbt.commit()
                     # it should have called put to overwrite a table and NOT called post
                     mock_put.assert_called_once()
-                    self.assertEqual(
-                        mock_put.call_args.kwargs["json"]["rows"]["$stashID"], self.stash_id)
                     # it should have NOT created a new table via post:
                     mock_post.assert_not_called()
 
     def test_commit_with_non_existing_table(self):
         # TODO: in a future version, we want to search for the table and if not found, create it. if found, update it (put).
         with patch.object(requests, "post") as mock_post:
-            self.mock_post_for_set_schema(mock_post)
-            self.gbt.set_schema(self.test_columns)
             test_rows = [
                 {"test-str": "one", "test-num": 1},
                 {"test-str": "two", "test-num": 2}
             ]
-            mock_post.reset_mock()
             self.gbt.add_rows(test_rows)
 
             with patch.object(requests, "get") as mock_get:
@@ -149,8 +100,6 @@ class TestGlideBigTableRestStrategy(unittest.TestCase):
                     self.gbt.commit()
                     # it should not have tried to overwrite a table with put
                     mock_put.assert_not_called()
-                    self.assertEqual(
-                        mock_post.call_args.kwargs["json"]["rows"]["$stashID"], self.stash_id)
                     # it should have created a new table with post:
                     mock_put.assert_not_called()
 


### PR DESCRIPTION
## What

- Don't call create stash endpoint; it will be removed soon
- Add `onSchemaError` flag to ignore columns that aren't in the schema
- Simplify by removing incremental/state handling machinery since we only support full reloads anyway
- Add missing step to readme
- Ignore `latest` tag in `push-docker-image` script

These bits have been pushed to the `glide-connectors` GAR as tag 0.0.30 and tested locally with 32,992 rows from an Airtable source.