### PR TITLE
fix:builds the AMD64 architecture image explicitly and pushes to Airbyte's repo for suing it in Airbyte Cloud

### DIFF
--- a/airbyte-integrations/connectors/destination-glide/scripts/build-docker-image.sh
+++ b/airbyte-integrations/connectors/destination-glide/scripts/build-docker-image.sh
@@ -3,5 +3,6 @@ this_dir=$(cd $(dirname "$0"); pwd) # this script's directory
 this_script=$(basename $0)
 
 # segment sometimes fails, so AIRBYTE_CI_DISABLE_TELEMETRY=true to disable it per airbyte-ci/connectors/pipelines/README.md
-AIRBYTE_CI_DISABLE_TELEMETRY=true airbyte-ci connectors --name=destination-glide build
-
+# see --architecture flag and available values in airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/commands.py
+AIRBYTE_CI_DISABLE_TELEMETRY=true airbyte-ci connectors --name=destination-glide build \
+  --architecture linux/amd64 --architecture linux/arm64

--- a/airbyte-integrations/connectors/destination-glide/scripts/push-docker-image.sh
+++ b/airbyte-integrations/connectors/destination-glide/scripts/push-docker-image.sh
@@ -2,18 +2,33 @@
 this_dir=$(cd $(dirname "$0"); pwd) # this script's directory
 this_script=$(basename $0)
 
-#!/usr/bin/env bash
-LOCAL_BUILT_IMAGE_NAME=airbyte/destination-glide:dev
-GLIDE_DOCKER_IMAGE_NAME=us-central1-docker.pkg.dev/glide-connectors/airbyte-glide-destination/destination-glide
+# So... it looks like when the airbyte-ci builds the multi-architecture images, it puts each one on a different tag locally.
+# We should probably push amd64 only or at least make it the "default" and make arm tagged sepraately. 
+# if we built and pushed all at once we could have a single tag for both architectures. However, we're using the airbyte-ci to build and that makes pushing a separate step.
+# It looks like there is experimental support for using docker manfiest to combine tags into a single multi-arch image at https://docs.docker.com/reference/cli/docker/manifest/
+LOCAL_BUILT_IMAGE_TAG_AMD64=dev-linux-amd64
+LOCAL_BUILT_IMAGE_TAG_ARM64=dev-linux-arm64
 
-echo "Pushing to remote image repository: $GLIDE_DOCKER_IMAGE_NAME"
-docker inspect --format='Pushing the local image "{{index .RepoTags 0}}" created at "{{.Created}}"' $LOCAL_BUILT_IMAGE_NAME
+LOCAL_BUILT_IMAGE_NAME=airbyte/destination-glide
+# GLIDE_DOCKER_IMAGE_NAME is really only useful if we want to use it entirely in Airbyte OSS. To use in Airbyte cloud we *must* push to the airbyte-managed repo.
+#GLIDE_DOCKER_IMAGE_NAME=us-central1-docker.pkg.dev/glide-connectors/airbyte-glide-destination/destination-glide
 
+# AIRBYTE_DOCKER_IMAGE_NAME is the repo we use for Airbyte's Cloud instance.
+GLIDE_AT_AIRBYTE_COMPANY_NAME=heyglide 
+AIRBYTE_DOCKER_IMAGE_NAME=us-central1-docker.pkg.dev/airbyte-custom-connectors/$GLIDE_AT_AIRBYTE_COMPANY_NAME/destination-glide
+
+echo "Will push to remote image repository: $AIRBYTE_DOCKER_IMAGE_NAME"
+
+docker inspect --format='Pushing the local image "{{index .RepoTags 0}}" created at "{{.Created}}"' $LOCAL_BUILT_IMAGE_NAME:$LOCAL_BUILT_IMAGE_TAG_AMD64
+if [ $? -ne 0 ]; then
+    echo "Error: The local image $LOCAL_BUILT_IMAGE_NAME does not exist.  Please build the image first."
+    exit 1
+fi
 
 # Fetch the list of tags from Docker Hub
 #tags=$(wget -q -O - "https://hub.docker.com/v2/namespaces/activescott/repositories/destination-glide/tags?page_size=10" | grep -o '"name": *"[^"]*' | grep -o '[^"]*$' | grep -E '([0-9]+\.)+[0-9]+' )
 # Get the list of tags using gcloud with the appropriate format
-tags=$(gcloud artifacts docker tags list $GLIDE_DOCKER_IMAGE_NAME --format="get(tag)")
+tags=$(gcloud artifacts docker tags list $AIRBYTE_DOCKER_IMAGE_NAME --format="get(tag)")
 
 # Sort the tags and get the highest one
 highest_tag=$(echo "$tags" | awk -F'/' '{print $NF}' | sed 's/latest//g' | sort -V | tail -n 1)
@@ -38,18 +53,26 @@ fi
 # Tag the local image with the new version
 # NOTE: airbyte/destination-glide is the local docker image that airbyte's CI builds and names locally.
 
-docker image tag $LOCAL_BUILT_IMAGE_NAME $GLIDE_DOCKER_IMAGE_NAME:$new_version
+docker image tag $LOCAL_BUILT_IMAGE_NAME:$LOCAL_BUILT_IMAGE_TAG_AMD64 $AIRBYTE_DOCKER_IMAGE_NAME:$new_version
+if [ $? -ne 0 ]; then
+    echo "Error: The local image $LOCAL_BUILT_IMAGE_NAME does not exist.  Please build the image first."
+    exit 1
+fi
 
 # Push the image with the new tag
-docker push $GLIDE_DOCKER_IMAGE_NAME:$new_version
+docker push $AIRBYTE_DOCKER_IMAGE_NAME:$new_version
+if [ $? -ne 0 ]; then
+    echo "Error: The local image $LOCAL_BUILT_IMAGE_NAME does not exist.  Please build the image first."
+    exit 1
+fi
 
 echo "Do you want to make this new version the 'latest' tag in Docker too (so that new pulls get this version by default)? (y/n)"
 read answer
 
 if [ "$answer" != "${answer#[Yy]}" ] ; then
     echo "Taging latest..."
-    docker image tag $LOCAL_BUILT_IMAGE_NAME $GLIDE_DOCKER_IMAGE_NAME:latest
-    docker push $GLIDE_DOCKER_IMAGE_NAME:latest
+    docker image tag $AIRBYTE_DOCKER_IMAGE_NAME:$new_version $AIRBYTE_DOCKER_IMAGE_NAME:latest
+    docker push $AIRBYTE_DOCKER_IMAGE_NAME:latest
 else
     echo "Exiting..."
     exit 0


### PR DESCRIPTION
This fixes the issue when trying to setup the destination in Airbyte cloud by explicitly building the amd64 image. I left it also building the arm64 image, but it only pushes am64 to airbytes repo. 

We could push the ARM64 image for working with Airbyte OSS locally on arm macs, but this will require one of two approaches:
1. Tagging it separately (we could just put an`-arm` postfix on the version tag?
2. In theory we could push a multi-architecture image, but since Airbyte builds it separately from pushing and tagging it, we have to use some experimental features in docker wrt manifest. 

Option 1 is the simplest if we care about this.

I also stopped pushing to the Glide-operated Image repo. While Airbyte told us to follow the OSS instructions which included using our own repo, when they enabled the custom docker connectors in Cloud - that ended up forcing us to use a docker image repo managed by them 🤦 So we could tear down that repo in gcloud and clean up the push script to clean this up further.

Let me know if you want me to make those changes or if you'd rather just run with this?