### PR TITLE
Fix/glide destination no type in schema

### DIFF
--- a/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
+++ b/airbyte-integrations/connectors/destination-glide/destination_glide/destination.py
@@ -95,7 +95,7 @@ class DestinationGlide(Destination):
             columns = []
             properties = configured_stream.stream.json_schema["properties"]
             for (prop_name, prop) in properties.items():
-                prop_type = prop["type"]
+                prop_type = prop["type"] if "type" in prop else ""
                 logger.debug(f"Found column/property '{prop_name}' with type '{prop_type}' in stream {configured_stream.stream.name}.")  # nopep8
                 columns.append(
                     Column(prop_name, airbyteTypeToGlideType(prop_type))


### PR DESCRIPTION
When importing `issues_timeline_events` from the Github source in Airbyte, the sync fails due to some columns missing a type property.

fixes glideapps/glide#29913
